### PR TITLE
Graphql: Schema rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/promaster-sdk/api-server/compare/v1.0.1...master)
 
+### Added
+
+- A lot of improvements for Client GrahQL API. ee PR [#4](https://github.com/promaster-sdk/api-server/pull/4).
+
 ## [v1.1.2](https://github.com/promaster-sdk/api-server/compare/v1.1.1...v1.1.2) - 2019-09-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@koa/cors": "^2.2.2",
     "convict": "^4.2.0",
+    "dataloader": "^1.4.0",
     "graphql": "^14.5.6",
     "graphql-tools": "^4.0.5",
     "koa": "^2.4.1",

--- a/src/client-graphql/context.ts
+++ b/src/client-graphql/context.ts
@@ -7,7 +7,6 @@ export type GetBaseUrl = (ctx: Koa.Context) => string;
 export type ReadJsonFile = <T>(fileName: string) => Promise<T>;
 
 export interface Context {
-  readonly getBaseUrl: GetBaseUrl;
   readonly readJsonFile: ReadJsonFile;
   readonly markerFile: ReleaseFile | TransactionFile;
   readonly markerName: string;
@@ -16,14 +15,12 @@ export interface Context {
 }
 
 export function createContext(
-  getBaseUrl: GetBaseUrl,
   readJsonFile: ReadJsonFile,
   markerName: string,
   markerFile: ReleaseFile | TransactionFile,
   rootFile: RootFile
 ): Context {
   return {
-    getBaseUrl,
     markerFile,
     rootFile,
     markerName,

--- a/src/client-graphql/context.ts
+++ b/src/client-graphql/context.ts
@@ -1,6 +1,6 @@
 import Koa from "koa";
 import DataLoader from "dataloader";
-import { ProductFile } from "../file-types";
+import { ProductFile, ReleaseFile, TransactionFile, RootFile } from "../file-types";
 
 export type GetBaseUrl = (ctx: Koa.Context) => string;
 
@@ -9,20 +9,23 @@ export type ReadJsonFile = <T>(fileName: string) => Promise<T>;
 export interface Context {
   readonly getBaseUrl: GetBaseUrl;
   readonly readJsonFile: ReadJsonFile;
-  readonly markerFileName: string;
+  readonly markerFile: ReleaseFile | TransactionFile;
   readonly markerName: string;
   readonly loaders: DataLoaders;
+  readonly rootFile: RootFile;
 }
 
 export function createContext(
   getBaseUrl: GetBaseUrl,
   readJsonFile: ReadJsonFile,
-  markerFileName: string,
-  markerName: string
+  markerName: string,
+  markerFile: ReleaseFile | TransactionFile,
+  rootFile: RootFile
 ): Context {
   return {
     getBaseUrl,
-    markerFileName,
+    markerFile,
+    rootFile,
     markerName,
     readJsonFile,
     loaders: createLoaders(readJsonFile),

--- a/src/client-graphql/context.ts
+++ b/src/client-graphql/context.ts
@@ -1,28 +1,44 @@
 import Koa from "koa";
+import DataLoader from "dataloader";
+import { ProductFile } from "../file-types";
 
-export interface GetBaseUrl {
-  (ctx: Koa.Context): string;
-}
+export type GetBaseUrl = (ctx: Koa.Context) => string;
 
 export type ReadJsonFile = <T>(fileName: string) => Promise<T>;
 
 export interface Context {
   readonly getBaseUrl: GetBaseUrl;
+  readonly readJsonFile: ReadJsonFile;
   readonly markerFileName: string;
   readonly markerName: string;
-  readonly readJsonFile: ReadJsonFile;
+  readonly loaders: DataLoaders;
 }
 
 export function createContext(
   getBaseUrl: GetBaseUrl,
+  readJsonFile: ReadJsonFile,
   markerFileName: string,
-  markerName: string,
-  readJsonFile: ReadJsonFile
+  markerName: string
 ): Context {
   return {
     getBaseUrl,
     markerFileName,
     markerName,
     readJsonFile,
+    loaders: createLoaders(readJsonFile),
+  };
+}
+
+export interface DataLoaders {
+  readonly productFiles: DataLoader<string, ProductFile>;
+}
+
+export function createLoaders(readJsonFile: ReadJsonFile): DataLoaders {
+  return {
+    productFiles: new DataLoader(async (filenames: ReadonlyArray<string>) => {
+      const promises = filenames.map((f) => readJsonFile<ProductFile>(f));
+      const promise = Promise.all(promises);
+      return await promise;
+    }),
   };
 }

--- a/src/client-graphql/context.ts
+++ b/src/client-graphql/context.ts
@@ -1,6 +1,6 @@
 import Koa from "koa";
 import DataLoader from "dataloader";
-import { ProductFile, ReleaseFile, TransactionFile, RootFile } from "../file-types";
+import { ProductFile, ReleaseFile, TransactionFile, RootFile, ProductTableFile } from "../file-types";
 
 export type GetBaseUrl = (ctx: Koa.Context) => string;
 
@@ -34,12 +34,18 @@ export function createContext(
 
 export interface DataLoaders {
   readonly productFiles: DataLoader<string, ProductFile>;
+  readonly tableFiles: DataLoader<string, ProductTableFile>;
 }
 
 export function createLoaders(readJsonFile: ReadJsonFile): DataLoaders {
   return {
     productFiles: new DataLoader(async (filenames: ReadonlyArray<string>) => {
       const promises = filenames.map((f) => readJsonFile<ProductFile>(f));
+      const promise = Promise.all(promises);
+      return await promise;
+    }),
+    tableFiles: new DataLoader(async (filenames: ReadonlyArray<string>) => {
+      const promises = filenames.map((f) => readJsonFile<ProductTableFile>(f));
       const promise = Promise.all(promises);
       return await promise;
     }),

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -49,8 +49,10 @@ function createGetMarkersMiddleware(getFilesDir: GetFilesDir, getBaseUrl: GetBas
 }
 
 interface ContextState {
-  readonly graphqlSchema: GraphQLSchema;
-  readonly graphqlContext: Context;
+  // tslint:disable-next-line:readonly-keyword
+  graphqlSchema: GraphQLSchema;
+  // tslint:disable-next-line:readonly-keyword
+  graphqlContext: Context;
 }
 
 /**
@@ -96,16 +98,13 @@ function createSchemaMiddleware(getFilesDir: GetFilesDir): Koa.Middleware<Contex
       };
       schemaPerMarker[marker] = markerSchema;
     }
-    ctx.state = {
-      ...ctx.state,
-      graphqlSchema: markerSchema.schema,
-      graphqlContext: createContext(
-        readJsonFile(getFilesDir(ctx)),
-        ctx.params.marker,
-        markerSchema.markerFile,
-        rootFile
-      ),
-    };
+    ctx.state.graphqlSchema = markerSchema.schema;
+    ctx.state.graphqlContext = createContext(
+      readJsonFile(getFilesDir(ctx)),
+      ctx.params.marker,
+      markerSchema.markerFile,
+      rootFile
+    );
     return next();
   };
 }

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -97,7 +97,7 @@ function createGraphQLMiddleware(getFilesDir: GetFilesDir, getBaseUrl: GetBaseUr
     schema: ctx.params.graphqlSchema,
     graphiql: true,
     rootValue: {} as RootValue,
-    context: createContext(getBaseUrl, ctx.params.markerFileName, ctx.params.marker, readJsonFile(getFilesDir(ctx))),
+    context: createContext(getBaseUrl, readJsonFile(getFilesDir(ctx)), ctx.params.markerFileName, ctx.params.marker),
     formatError: (error: GraphQLError) => {
       console.log("Error occured in GraphQL:");
       console.log(error);

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -5,7 +5,7 @@ import Koa from "koa";
 import Router from "koa-router";
 import compose from "koa-compose";
 import graphqlHTTP from "koa-graphql";
-import { GraphQLError } from "graphql";
+import { GraphQLError, GraphQLSchema } from "graphql";
 import { createSchema } from "./schema";
 import { GetBaseUrl, createContext } from "./context";
 import { RootValue } from "./resolvers";
@@ -14,6 +14,7 @@ import { buildRootFileName, RootFile } from "../file-types";
 const readFileAsync = promisify(fs.readFile);
 
 export const readJsonFile = <T>(filesDir: string) => async (fileName: string): Promise<T> => {
+  console.log("readJsonFile", fileName);
   const fullPath = path.join(filesDir, fileName);
   const content = JSON.parse(await readFileAsync(fullPath, "utf8"));
   return content;
@@ -28,10 +29,10 @@ export function createClientGraphQLMiddleware(
   getBaseUrl: GetBaseUrl,
   prefix?: string
 ): Koa.Middleware {
-  interface MiddlewarePerMarker {
-    [marker: string]: { markerFileName: string; middleware: Koa.Middleware } | undefined;
-  }
-  const middlewarePerMarker: MiddlewarePerMarker = {};
+  // interface MiddlewarePerMarker {
+  //   [marker: string]: { markerFileName: string; middleware: Koa.Middleware } | undefined;
+  // }
+  // const middlewarePerMarker: MiddlewarePerMarker = {};
   const router = new Router({ prefix });
 
   router.all("/", async (ctx, next) => {
@@ -42,50 +43,103 @@ export function createClientGraphQLMiddleware(
     return next();
   });
 
-  router.all("/:marker", async (ctx, next) => {
+  router.all(
+    "/:marker",
+    createSchemaMiddleware(getFilesDir),
+    createGraphQLMiddleware2(getFilesDir, getBaseUrl)
+    // async (ctx, next) => {
+    //   const { marker, graphqlSchema } = ctx.params;
+    //   console.log("HEJEHEJEHJEHJHE", graphqlSchema);
+    //   const rootFileContent = await readJsonFile<RootFile>(getFilesDir(ctx))(buildRootFileName());
+    //   const markerLowerCase = marker.toLowerCase();
+    //   const markerKey = Object.keys(rootFileContent.data.markers).find((m) => m.toLowerCase() === markerLowerCase);
+    //   const markerRef = rootFileContent.data.markers[markerKey || ""];
+    //   const markerFileName = rootFileContent.refs[markerRef];
+    //   if (!markerFileName) {
+    //     ctx.body = `Marker ${marker} not found.`;
+    //     ctx.status = 404;
+    //     return next();
+    //   }
+    //   let markerMiddleware = middlewarePerMarker[marker];
+    //   console.log("markerMiddleware1", markerMiddleware);
+    //   if (markerMiddleware) {
+    //     // If marker is pointing to new file, then delete old middleware from memory
+    //     if (markerMiddleware.markerFileName !== markerFileName) {
+    //       delete middlewarePerMarker[marker];
+    //       markerMiddleware = undefined;
+    //     }
+    //   }
+    //   console.log("markerMiddleware2", markerMiddleware);
+    //   if (!markerMiddleware) {
+    //     markerMiddleware = {
+    //       markerFileName,
+    //       middleware: createGraphQLMiddleware(getFilesDir, getBaseUrl, markerFileName, marker),
+    //     };
+    //     middlewarePerMarker[marker] = markerMiddleware;
+    //   }
+    //   console.log("markerMiddleware3", markerMiddleware);
+    //   return markerMiddleware.middleware(ctx, next);
+    // }
+  );
+
+  return compose([router.routes(), router.allowedMethods()]);
+}
+
+// This middleware expects ctx.params.marker, and adds a schema for that marker to the context
+function createSchemaMiddleware(getFilesDir: GetFilesDir): Koa.Middleware {
+  interface SchemaPerMarker {
+    [marker: string]: GraphQLSchema;
+  }
+  const schemaPerMarker: SchemaPerMarker = {};
+  return async (ctx, next) => {
     const { marker } = ctx.params;
-    const rootFileContent = await readJsonFile<RootFile>(getFilesDir(ctx))(buildRootFileName());
-    const markerLowerCase = marker.toLowerCase();
-    const markerKey = Object.keys(rootFileContent.data.markers).find((m) => m.toLowerCase() === markerLowerCase);
-    const markerRef = rootFileContent.data.markers[markerKey || ""];
-    const markerFileName = rootFileContent.refs[markerRef];
+    const markerFileName = await getMarkerFileName(getFilesDir, ctx, marker);
     if (!markerFileName) {
       ctx.body = `Marker ${marker} not found.`;
       ctx.status = 404;
       return next();
     }
-    let markerMiddleware = middlewarePerMarker[marker];
-    if (markerMiddleware) {
-      // If marker is pointing to new file, then delete old middleware from memory
-      if (markerMiddleware.markerFileName !== markerFileName) {
-        delete middlewarePerMarker[marker];
-        markerMiddleware = undefined;
-      }
+    if (schemaPerMarker[marker] === undefined) {
+      console.log("Creating new schema!!!!!");
+      schemaPerMarker[marker] = await createSchema(readJsonFile(getFilesDir(ctx)), markerFileName);
     }
-    if (!markerMiddleware) {
-      markerMiddleware = {
-        markerFileName,
-        middleware: createGraphQLMiddleware(getFilesDir, getBaseUrl, markerFileName, marker),
-      };
-      middlewarePerMarker[marker] = markerMiddleware;
-    }
-    return markerMiddleware.middleware(ctx, next);
-  });
-
-  return compose([router.routes(), router.allowedMethods()]);
+    ctx.params.graphqlSchema = schemaPerMarker[marker];
+    return next();
+  };
 }
 
-function createGraphQLMiddleware(
-  getFilesDir: GetFilesDir,
-  getBaseUrl: GetBaseUrl,
-  markerFileName: string,
-  marker: string
-): Koa.Middleware {
+// function createGraphQLMiddleware(
+//   getFilesDir: GetFilesDir,
+//   getBaseUrl: GetBaseUrl,
+//   markerFileName: string,
+//   marker: string
+// ): Koa.Middleware {
+//   return graphqlHTTP(async (_request, _repsonse, ctx) => ({
+//     schema: await createSchema(readJsonFile(getFilesDir(ctx)), markerFileName),
+//     graphiql: true,
+//     rootValue: {} as RootValue,
+//     context: createContext(getBaseUrl, markerFileName, marker, readJsonFile(getFilesDir(ctx))),
+//     formatError: (error: GraphQLError) => {
+//       console.log("Error occured in GraphQL:");
+//       console.log(error);
+//       console.log("The original error was:");
+//       console.log(error.originalError);
+//       return error;
+//     },
+//   }));
+// }
+
+function createGraphQLMiddleware2(getFilesDir: GetFilesDir, getBaseUrl: GetBaseUrl): Koa.Middleware {
   return graphqlHTTP(async (_request, _repsonse, ctx) => ({
-    schema: await createSchema(readJsonFile(getFilesDir(ctx)), markerFileName),
+    schema: ctx.params.graphqlSchema,
     graphiql: true,
     rootValue: {} as RootValue,
-    context: createContext(getBaseUrl, markerFileName, marker, readJsonFile(getFilesDir(ctx))),
+    context: createContext(
+      getBaseUrl,
+      (await getMarkerFileName(getFilesDir, ctx, ctx.params.marker)) || "",
+      ctx.params.marker,
+      readJsonFile(getFilesDir(ctx))
+    ),
     formatError: (error: GraphQLError) => {
       console.log("Error occured in GraphQL:");
       console.log(error);
@@ -94,4 +148,17 @@ function createGraphQLMiddleware(
       return error;
     },
   }));
+}
+
+async function getMarkerFileName(
+  getFilesDir: GetFilesDir,
+  ctx: Koa.Context,
+  marker: string
+): Promise<string | undefined> {
+  const rootFileContent = await readJsonFile<RootFile>(getFilesDir(ctx))(buildRootFileName());
+  const markerLowerCase = marker.toLowerCase();
+  const markerKey = Object.keys(rootFileContent.data.markers).find((m) => m.toLowerCase() === markerLowerCase);
+  const markerRef = rootFileContent.data.markers[markerKey || ""];
+  const markerFileName = rootFileContent.refs[markerRef];
+  return markerFileName;
 }

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -58,7 +58,7 @@ interface ContextState {
  * It will cache the created schema until the marker is pointing to a new file.
  */
 function createSchemaMiddleware(getFilesDir: GetFilesDir): Koa.Middleware<ContextState> {
-  interface SchemaPerMarker {
+  const schemaPerMarker: {
     [marker: string]:
       | {
           readonly markerFileName: string;
@@ -66,8 +66,7 @@ function createSchemaMiddleware(getFilesDir: GetFilesDir): Koa.Middleware<Contex
           readonly schema: GraphQLSchema;
         }
       | undefined;
-  }
-  const schemaPerMarker: SchemaPerMarker = {};
+  } = {};
   return async (ctx, next) => {
     const { marker } = ctx.params;
     const rootFile = await readJsonFile<RootFile>(getFilesDir(ctx))(buildRootFileName());

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -14,8 +14,6 @@ import { buildRootFileName, RootFile } from "../file-types";
 const readFileAsync = promisify(fs.readFile);
 
 export const readJsonFile = <T>(filesDir: string) => async (fileName: string): Promise<T> => {
-  console.log("filesDir", filesDir);
-  console.log("fileName", fileName);
   const fullPath = path.join(filesDir, fileName);
   const content = JSON.parse(await readFileAsync(fullPath, "utf8"));
   return content;

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -14,6 +14,8 @@ import { buildRootFileName, RootFile } from "../file-types";
 const readFileAsync = promisify(fs.readFile);
 
 export const readJsonFile = <T>(filesDir: string) => async (fileName: string): Promise<T> => {
+  console.log("filesDir", filesDir);
+  console.log("fileName", fileName);
   const fullPath = path.join(filesDir, fileName);
   const content = JSON.parse(await readFileAsync(fullPath, "utf8"));
   return content;

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -14,7 +14,7 @@ import { buildRootFileName, RootFile, ReleaseFile, TransactionFile } from "../fi
 const readFileAsync = promisify(fs.readFile);
 
 export const readJsonFile = <T>(filesDir: string) => async (fileName: string): Promise<T> => {
-  console.log("readJsonFile", fileName);
+  // console.log("readJsonFile", fileName);
   const fullPath = path.join(filesDir, fileName);
   const content = JSON.parse(await readFileAsync(fullPath, "utf8"));
   return content;

--- a/src/client-graphql/middleware.ts
+++ b/src/client-graphql/middleware.ts
@@ -36,7 +36,7 @@ export function createClientGraphQLMiddleware(
 
   router.all("/", async (ctx, next) => {
     const rootFileContent = await readJsonFile<RootFile>(getFilesDir(ctx))(buildRootFileName());
-    const markers = Object.keys(rootFileContent.data.markers);
+    const markers = Object.keys(rootFileContent.data.markers).map((m) => m.toLowerCase());
     const urlsToMarkers = markers.map((m) => `${getBaseUrl(ctx)}/${m}`);
     ctx.body = urlsToMarkers;
     return next();
@@ -45,7 +45,9 @@ export function createClientGraphQLMiddleware(
   router.all("/:marker", async (ctx, next) => {
     const { marker } = ctx.params;
     const rootFileContent = await readJsonFile<RootFile>(getFilesDir(ctx))(buildRootFileName());
-    const markerRef = rootFileContent.data.markers[marker];
+    const markerLowerCase = marker.toLowerCase();
+    const markerKey = Object.keys(rootFileContent.data.markers).find((m) => m.toLowerCase() === markerLowerCase);
+    const markerRef = rootFileContent.data.markers[markerKey || ""];
     const markerFileName = rootFileContent.refs[markerRef];
     if (!markerFileName) {
       ctx.body = `Marker ${marker} not found.`;

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -64,7 +64,6 @@ export const productResolvers: {
   key: async (parent, _args, ctx) => (await ctx.loaders.productFiles.load(parent)).data.key,
   name: async (parent, _args: {}, ctx) => (await ctx.loaders.productFiles.load(parent)).data.name,
   retired: async (parent, _args: {}, ctx) => (await ctx.loaders.productFiles.load(parent)).data.retired,
-  _fileName: async (parent, _args: {}, _ctx) => parent,
   modules: async (parent, _args, ctx) => {
     const { readJsonFile } = ctx;
     const productFile = await ctx.loaders.productFiles.load(parent);
@@ -90,5 +89,5 @@ export const productResolvers: {
 
 async function getProduct(readJsonFile: ReadJsonFile, productFileName: string): Promise<Product> {
   const productFile: ProductFile = await readJsonFile<ProductFile>(productFileName);
-  return { ...productFile.data, _fileName: productFileName, modules: {} };
+  return { ...productFile.data, modules: {} };
 }

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -75,20 +75,6 @@ export const queryResolvers = {
   },
 };
 
-// async function getOrLoadProduct(ctx: Context, filename: string): Promise<Product> {
-//   console.log("ctx.resolverCache.loadedProducts0", ctx.resolverCache.loadedProducts);
-//   const { readJsonFile } = ctx;
-//   let product = ctx.resolverCache.loadedProducts[filename];
-//   if (!product) {
-//     console.log("ctx.resolverCache.loadedProducts1", ctx.resolverCache.loadedProducts);
-//     product = await getProduct(readJsonFile, filename);
-//     console.log("ctx.resolverCache.loadedProducts2", ctx.resolverCache.loadedProducts);
-//     ctx.resolverCache.loadedProducts[filename] = product;
-//   }
-//   // console.log(product);
-//   return product;
-// }
-
 // tslint:disable-next-line:no-any
 export const productResolvers: { [P in keyof Product]?: any } = {
   id: async (parent: ProductFileName, _args: {}, ctx: Context): Promise<string> => {
@@ -99,14 +85,16 @@ export const productResolvers: { [P in keyof Product]?: any } = {
     const productFile = await ctx.loaders.productFiles.load(parent);
     return productFile.data.key;
   },
-  name: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
-    return "hehe";
+  name: async (parent: ProductFileName, _args: {}, ctx: Context): Promise<string> => {
+    const productFile = await ctx.loaders.productFiles.load(parent);
+    return productFile.data.name;
   },
-  retired: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
-    return "hehe";
+  retired: async (parent: ProductFileName, _args: {}, ctx: Context): Promise<boolean> => {
+    const productFile = await ctx.loaders.productFiles.load(parent);
+    return productFile.data.retired;
   },
-  _fileName: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
-    return "hehe";
+  _fileName: async (parent: ProductFileName, _args: {}, _ctx: Context): Promise<string> => {
+    return parent;
   },
   modules: async (parent: Product, _args: {}, ctx: Context): Promise<Modules> => {
     const { readJsonFile } = ctx;

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -1,14 +1,4 @@
-import {
-  RootFile,
-  buildRootFileName,
-  TreeFile,
-  getTypeAndIdentifierFromFileName,
-  ReleaseFile,
-  parseTransactionFileName,
-  ProductFile,
-  ProductTableFile,
-  TransactionFile,
-} from "../file-types";
+import { TreeFile, ReleaseFile, ProductFile, ProductTableFile, TransactionFile } from "../file-types";
 import { Context, ReadJsonFile } from "./context";
 import { Marker, Product, Modules } from "./schema-types";
 
@@ -19,54 +9,47 @@ type ProductFileName = string;
 
 export const queryResolvers = {
   trees: async (_parent: RootValue, _args: {}, ctx: Context) => {
-    const { readJsonFile } = ctx;
-    const rootFileContent = await readJsonFile<RootFile>(buildRootFileName());
+    const { rootFile, readJsonFile } = ctx;
+    // const rootFile = await readJsonFile<RootFile>(buildRootFileName());
     const trees: Array<TreeFile> = [];
-    for (const t of Object.keys(rootFileContent.data.trees)) {
-      const fileName = rootFileContent.refs[rootFileContent.data.trees[t]];
+    for (const t of Object.keys(rootFile.data.trees)) {
+      const fileName = rootFile.refs[rootFile.data.trees[t]];
       const treeContent = await readJsonFile<TreeFile>(fileName);
       trees.push(treeContent);
     }
     return trees;
   },
   marker: async (_parent: RootValue, _args: {}, ctx: Context): Promise<Marker> => {
-    const { markerFileName, markerName, readJsonFile } = ctx;
-    const typeAndId = getTypeAndIdentifierFromFileName(markerFileName);
-    if (typeAndId.type === "release") {
-      const releaseContent = await readJsonFile<ReleaseFile>(markerFileName);
+    const { markerFile, markerName } = ctx;
+    if ((markerFile as ReleaseFile).data.name) {
+      const releaseFile = markerFile as ReleaseFile;
       return {
         markerName: markerName,
-        releaseName: releaseContent.data.name,
-        releaseId: releaseContent.data.id.toUpperCase(),
+        releaseName: releaseFile.data.name,
+        releaseId: releaseFile.data.id.toUpperCase(),
       };
-    } else if (typeAndId.type === "transaction") {
-      const parsed = parseTransactionFileName(markerFileName);
-      const tx = parsed.tx;
+    } else if ((markerFile as TransactionFile).data.tx) {
+      const transactionFile = markerFile as TransactionFile;
       return {
         markerName: markerName,
-        tx: tx.toString(),
+        tx: transactionFile.data.tx.toString(),
       };
     } else {
       throw new Error("Invalid file type.");
     }
   },
   products: async (_parent: RootValue, _args: {}, ctx: Context): Promise<ProductFileNames> => {
-    const { readJsonFile, markerFileName } = ctx;
-    const markerFile = await readJsonFile<ReleaseFile | TransactionFile>(markerFileName);
+    const { markerFile } = ctx;
     const productFileNames = Object.values(markerFile.data.products).map((ref) => markerFile.refs[ref]);
     return productFileNames;
-    // const productPromises = productFileNames.map((f) => getProduct(readJsonFile, f));
-    // const products = await Promise.all(productPromises);
-    // return products;
   },
   product: async (_parent: RootValue, { id }: { readonly id: string }, ctx: Context) => {
-    const { readJsonFile, markerFileName } = ctx;
-    const releaseFile = await readJsonFile<ReleaseFile | TransactionFile>(markerFileName);
-    const productFileRef = releaseFile.data.products[id];
+    const { readJsonFile, markerFile } = ctx;
+    const productFileRef = markerFile.data.products[id];
     if (productFileRef === undefined) {
       return null;
     }
-    const productFile = releaseFile.refs[productFileRef];
+    const productFile = markerFile.refs[productFileRef];
     if (productFile === undefined) {
       return null;
     }

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -14,6 +14,8 @@ import { Marker, Product, Modules } from "./schema-types";
 
 export type RootValue = {};
 
+type ProductFileNames = ReadonlyArray<string>;
+
 export const queryResolvers = {
   trees: async (_parent: RootValue, _args: {}, ctx: Context) => {
     const { readJsonFile } = ctx;
@@ -47,13 +49,14 @@ export const queryResolvers = {
       throw new Error("Invalid file type.");
     }
   },
-  products: async (_parent: RootValue, _args: {}, ctx: Context) => {
+  products: async (_parent: RootValue, _args: {}, ctx: Context): Promise<ProductFileNames> => {
     const { readJsonFile, markerFileName } = ctx;
-    const releaseFile = await readJsonFile<ReleaseFile | TransactionFile>(markerFileName);
-    const productFileNames = Object.values(releaseFile.data.products).map((ref) => releaseFile.refs[ref]);
-    const productPromises = productFileNames.map((f) => getProduct(readJsonFile, f));
-    const products = await Promise.all(productPromises);
-    return products;
+    const markerFile = await readJsonFile<ReleaseFile | TransactionFile>(markerFileName);
+    const productFileNames = Object.values(markerFile.data.products).map((ref) => markerFile.refs[ref]);
+    return productFileNames;
+    // const productPromises = productFileNames.map((f) => getProduct(readJsonFile, f));
+    // const products = await Promise.all(productPromises);
+    // return products;
   },
   product: async (_parent: RootValue, { id }: { readonly id: string }, ctx: Context) => {
     const { readJsonFile, markerFileName } = ctx;
@@ -71,7 +74,23 @@ export const queryResolvers = {
   },
 };
 
-export const productResolvers = {
+// tslint:disable-next-line:no-any
+export const productResolvers: { [P in keyof Product]?: any } = {
+  id: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
+    return "hehe";
+  },
+  key: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
+    return "hehe";
+  },
+  name: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
+    return "hehe";
+  },
+  retired: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
+    return "hehe";
+  },
+  _fileName: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
+    return "hehe";
+  },
   modules: async (parent: Product, _args: {}, ctx: Context): Promise<Modules> => {
     const { readJsonFile } = ctx;
     const product = await readJsonFile<ProductFile>(parent._fileName);
@@ -97,5 +116,5 @@ export const productResolvers = {
 
 async function getProduct(readJsonFile: ReadJsonFile, productFileName: string): Promise<Product> {
   const productFile: ProductFile = await readJsonFile<ProductFile>(productFileName);
-  return { ...productFile.data, _fileName: productFileName };
+  return { ...productFile.data, _fileName: productFileName, modules: {} };
 }

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -61,25 +61,11 @@ export const queryResolvers = {
 export const productResolvers: {
   [P in keyof Product]?: (parent: ProductFileName, args: {}, ctx: Context) => Promise<Product[P]>
 } = {
-  id: async (parent, _args, ctx) => {
-    const productFile = await ctx.loaders.productFiles.load(parent);
-    return productFile.data.id;
-  },
-  key: async (parent, _args, ctx): Promise<string> => {
-    const productFile = await ctx.loaders.productFiles.load(parent);
-    return productFile.data.key;
-  },
-  name: async (parent: ProductFileName, _args: {}, ctx: Context): Promise<string> => {
-    const productFile = await ctx.loaders.productFiles.load(parent);
-    return productFile.data.name;
-  },
-  retired: async (parent: ProductFileName, _args: {}, ctx: Context): Promise<boolean> => {
-    const productFile = await ctx.loaders.productFiles.load(parent);
-    return productFile.data.retired;
-  },
-  _fileName: async (parent: ProductFileName, _args: {}, _ctx: Context): Promise<string> => {
-    return parent;
-  },
+  id: async (parent, _args, ctx) => (await ctx.loaders.productFiles.load(parent)).data.id,
+  key: async (parent, _args, ctx) => (await ctx.loaders.productFiles.load(parent)).data.key,
+  name: async (parent, _args: {}, ctx) => (await ctx.loaders.productFiles.load(parent)).data.name,
+  retired: async (parent, _args: {}, ctx) => (await ctx.loaders.productFiles.load(parent)).data.retired,
+  _fileName: async (parent, _args: {}, _ctx) => parent,
   modules: async (parent, _args, ctx) => {
     const { readJsonFile } = ctx;
     const productFile = await ctx.loaders.productFiles.load(parent);

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -1,6 +1,7 @@
-import { TreeFile, ReleaseFile, ProductTableFile, TransactionFile } from "../file-types";
+import { TreeFile, ReleaseFile, TransactionFile, ProductTableFile } from "../file-types";
 import { Context } from "./context";
-import { Query, Marker, Product } from "./schema-types";
+import { Query, Marker, Product, TableRow } from "./schema-types";
+import { GraphQLResolveInfo } from "graphql";
 
 export type RootValue = {};
 
@@ -62,32 +63,91 @@ export const queryResolvers: {
   },
 };
 
+type ProductParents = {
+  readonly id: Product["id"];
+  readonly key: Product["key"];
+  readonly name: Product["name"];
+  readonly retired: Product["retired"];
+  readonly modules: ProductFileName;
+};
+
 export const productResolvers: {
-  [P in keyof Product]?: (parent: ProductFileName, args: {}, ctx: Context) => Promise<Product[P]>
+  [P in keyof Product]?: (parent: ProductFileName, args: {}, ctx: Context) => Promise<ProductParents[P]>
 } = {
   id: async (parent, _args, ctx) => (await ctx.loaders.productFiles.load(parent)).data.id,
   key: async (parent, _args, ctx) => (await ctx.loaders.productFiles.load(parent)).data.key,
   name: async (parent, _args: {}, ctx) => (await ctx.loaders.productFiles.load(parent)).data.name,
   retired: async (parent, _args: {}, ctx) => (await ctx.loaders.productFiles.load(parent)).data.retired,
-  modules: async (parent, _args, ctx) => {
-    const { readJsonFile } = ctx;
-    const productFile = await ctx.loaders.productFiles.load(parent);
-    const tableFileNames = Object.values(productFile.data.tables).map((v) => productFile.refs[v]);
-    const tablePromises = tableFileNames.map((f) => readJsonFile<ProductTableFile>(f));
-    const tables = await Promise.all(tablePromises);
-    // Group tables by module
-    const tablesByModule: {
-      [module: string]: { [table: string]: Array<{ [column: string]: string | number | null }> };
-    } = {};
-    for (const t of tables) {
-      let moduleWithTables = tablesByModule[t.data.module];
-      if (!moduleWithTables) {
-        moduleWithTables = {};
-        tablesByModule[t.data.module] = moduleWithTables;
-      }
-      const rows = t.data.rows.map((values) => Object.fromEntries(t.data.columns.map((c, i) => [c.name, values[i]])));
-      moduleWithTables[t.data.name] = rows;
-    }
-    return tablesByModule;
+  modules: async (parent, _args, _ctx) => {
+    // const { readJsonFile } = ctx;
+    // const productFile = await ctx.loaders.productFiles.load(parent);
+    // const tableFileNames = Object.values(productFile.data.tables).map((v) => productFile.refs[v]);
+    // const tablePromises = tableFileNames.map((f) => readJsonFile<ProductTableFile>(f));
+    // const tables = await Promise.all(tablePromises);
+    // // Group tables by module
+    // const tablesByModule: {
+    //   [module: string]: { [table: string]: Array<{ [column: string]: string | number | null }> };
+    // } = {};
+    // for (const t of tables) {
+    //   let moduleWithTables = tablesByModule[t.data.module];
+    //   if (!moduleWithTables) {
+    //     moduleWithTables = {};
+    //     tablesByModule[t.data.module] = moduleWithTables;
+    //   }
+    //   const rows = t.data.rows.map((values) => Object.fromEntries(t.data.columns.map((c, i) => [c.name, values[i]])));
+    //   moduleWithTables[t.data.name] = rows;
+    // }
+    // return tablesByModule;
+    return parent;
   },
 };
+
+export function modulesFieldResolver(
+  parent: string,
+  _args: {},
+  _ctx: Context,
+  info: GraphQLResolveInfo
+): ModuleFieldResolverParent {
+  return { module: info.fieldName, productFileName: parent };
+}
+
+interface ModuleFieldResolverParent {
+  readonly module: string;
+  readonly productFileName: ProductFileName;
+}
+
+export async function moduleFieldResolver(
+  parent: ModuleFieldResolverParent,
+  _args: {},
+  ctx: Context,
+  info: GraphQLResolveInfo
+): Promise<ReadonlyArray<TableRow>> {
+  const fullTableName = `${parent.module}@${info.fieldName}`;
+  const productFile = await ctx.loaders.productFiles.load(parent.productFileName);
+  const tableRef = productFile.data.tables[fullTableName];
+  const tableFileName = productFile.refs[tableRef];
+  console.log("tableFileName", tableFileName);
+  const tableFile = await ctx.loaders.tableFiles.load(tableFileName);
+  console.log("tableFile", tableFile);
+
+  // ---
+  const { readJsonFile } = ctx;
+  const tableFileNames = Object.values(productFile.data.tables).map((v) => productFile.refs[v]);
+  const tablePromises = tableFileNames.map((f) => readJsonFile<ProductTableFile>(f));
+  const tables = await Promise.all(tablePromises);
+  // Group tables by module
+  const tablesByModule: {
+    [module: string]: { [table: string]: Array<{ [column: string]: string | number | null }> };
+  } = {};
+  for (const t of tables) {
+    let moduleWithTables = tablesByModule[t.data.module];
+    if (!moduleWithTables) {
+      moduleWithTables = {};
+      tablesByModule[t.data.module] = moduleWithTables;
+    }
+    const rows = t.data.rows.map((values) => Object.fromEntries(t.data.columns.map((c, i) => [c.name, values[i]])));
+    moduleWithTables[t.data.name] = rows;
+  }
+
+  return tablesByModule[parent.module][info.fieldName];
+}

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -14,7 +14,8 @@ import { Marker, Product, Modules } from "./schema-types";
 
 export type RootValue = {};
 
-type ProductFileNames = ReadonlyArray<string>;
+type ProductFileNames = ReadonlyArray<ProductFileName>;
+type ProductFileName = string;
 
 export const queryResolvers = {
   trees: async (_parent: RootValue, _args: {}, ctx: Context) => {
@@ -74,13 +75,29 @@ export const queryResolvers = {
   },
 };
 
+// async function getOrLoadProduct(ctx: Context, filename: string): Promise<Product> {
+//   console.log("ctx.resolverCache.loadedProducts0", ctx.resolverCache.loadedProducts);
+//   const { readJsonFile } = ctx;
+//   let product = ctx.resolverCache.loadedProducts[filename];
+//   if (!product) {
+//     console.log("ctx.resolverCache.loadedProducts1", ctx.resolverCache.loadedProducts);
+//     product = await getProduct(readJsonFile, filename);
+//     console.log("ctx.resolverCache.loadedProducts2", ctx.resolverCache.loadedProducts);
+//     ctx.resolverCache.loadedProducts[filename] = product;
+//   }
+//   // console.log(product);
+//   return product;
+// }
+
 // tslint:disable-next-line:no-any
 export const productResolvers: { [P in keyof Product]?: any } = {
-  id: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
-    return "hehe";
+  id: async (parent: ProductFileName, _args: {}, ctx: Context): Promise<string> => {
+    const productFile = await ctx.loaders.productFiles.load(parent);
+    return productFile.data.id;
   },
-  key: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
-    return "hehe";
+  key: async (parent: ProductFileName, _args: {}, ctx: Context): Promise<string> => {
+    const productFile = await ctx.loaders.productFiles.load(parent);
+    return productFile.data.key;
   },
   name: async (_parent: Product, _args: {}, _ctx: Context): Promise<string> => {
     return "hehe";

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -57,7 +57,6 @@ export const queryResolvers = {
   },
 };
 
-// tslint:disable-next-line:no-any
 export const productResolvers: {
   [P in keyof Product]?: (parent: ProductFileName, args: {}, ctx: Context) => Promise<Product[P]>
 } = {

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -43,7 +43,7 @@ export const queryResolvers: {
         tx: transactionFile.data.tx.toString(),
       };
     } else {
-      throw new Error("Invalid file type.");
+      throw new Error("Invalid marker.");
     }
   },
   products: async (_parent, _args: {}, ctx: Context): Promise<ProductFileNames> => {

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -55,6 +55,20 @@ export const queryResolvers = {
     const products = await Promise.all(productPromises);
     return products;
   },
+  product: async (_parent: RootValue, { id }: { readonly id: string }, ctx: Context) => {
+    const { readJsonFile, markerFileName } = ctx;
+    const releaseFile = await readJsonFile<ReleaseFile | TransactionFile>(markerFileName);
+    const productFileRef = releaseFile.data.products[id];
+    if (productFileRef === undefined) {
+      return null;
+    }
+    const productFile = releaseFile.refs[productFileRef];
+    if (productFile === undefined) {
+      return null;
+    }
+    const product = await getProduct(readJsonFile, productFile);
+    return product;
+  },
 };
 
 export const productResolvers = {

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -1,13 +1,22 @@
 import { TreeFile, ReleaseFile, ProductFile, ProductTableFile, TransactionFile } from "../file-types";
 import { Context, ReadJsonFile } from "./context";
-import { Marker, Product } from "./schema-types";
+import { Query, Marker, Product } from "./schema-types";
 
 export type RootValue = {};
 
 type ProductFileNames = ReadonlyArray<ProductFileName>;
 type ProductFileName = string;
 
-export const queryResolvers = {
+type QueryParents = {
+  readonly trees: Query["trees"];
+  readonly marker: Query["marker"];
+  readonly products: ProductFileNames;
+  readonly product: Query["product"];
+};
+
+export const queryResolvers: {
+  [P in keyof Query]?: (parent: RootValue, args: {}, ctx: Context) => Promise<QueryParents[P]>
+} = {
   trees: async (_parent: RootValue, _args: {}, ctx: Context) => {
     const { rootFile, readJsonFile } = ctx;
     const trees: Array<TreeFile> = [];
@@ -37,7 +46,7 @@ export const queryResolvers = {
       throw new Error("Invalid file type.");
     }
   },
-  products: async (_parent: RootValue, _args: {}, ctx: Context): Promise<ProductFileNames> => {
+  products: async (_parent, _args: {}, ctx: Context): Promise<ProductFileNames> => {
     const { markerFile } = ctx;
     const productFileNames = Object.values(markerFile.data.products).map((ref) => markerFile.refs[ref]);
     return productFileNames;

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -105,6 +105,9 @@ export async function moduleFieldResolver(
   const productFile = await ctx.loaders.productFiles.load(parent.productFileName);
   const tableRef = productFile.data.tables[fullTableName];
   const tableFileName = productFile.refs[tableRef];
+  if (!tableFileName) {
+    return [];
+  }
   const tableFile = await ctx.loaders.tableFiles.load(tableFileName);
   const rows = tableFile.data.rows.map((values) =>
     Object.fromEntries(tableFile.data.columns.map((c, i) => [c.name, values[i]]))

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -35,7 +35,6 @@ export const queryResolvers = {
         markerName: markerName,
         releaseName: releaseContent.data.name,
         releaseId: releaseContent.data.id.toUpperCase(),
-        _fileName: markerFileName,
       };
     } else if (typeAndId.type === "transaction") {
       const parsed = parseTransactionFileName(markerFileName);
@@ -43,22 +42,18 @@ export const queryResolvers = {
       return {
         markerName: markerName,
         tx: tx.toString(),
-        _fileName: markerFileName,
       };
     } else {
       throw new Error("Invalid file type.");
     }
   },
-};
-
-export const markerResolvers = {
-  products: async (parent: Marker, _args: {}, ctx: Context) => {
-    const { readJsonFile } = ctx;
-    const releaseFile = await readJsonFile<ReleaseFile | TransactionFile>(parent._fileName);
+  products: async (_parent: RootValue, _args: {}, ctx: Context) => {
+    const { readJsonFile, markerFileName } = ctx;
+    const releaseFile = await readJsonFile<ReleaseFile | TransactionFile>(markerFileName);
     const productFileNames = Object.values(releaseFile.data.products).map((ref) => releaseFile.refs[ref]);
-    const apiProductPromises = productFileNames.map((f) => getProduct(readJsonFile, f));
-    const apiProducts = await Promise.all(apiProductPromises);
-    return apiProducts;
+    const productPromises = productFileNames.map((f) => getProduct(readJsonFile, f));
+    const products = await Promise.all(productPromises);
+    return products;
   },
 };
 

--- a/src/client-graphql/resolvers.ts
+++ b/src/client-graphql/resolvers.ts
@@ -1,7 +1,7 @@
+import { GraphQLResolveInfo } from "graphql";
 import { TreeFile, ReleaseFile, TransactionFile } from "../file-types";
 import { Context } from "./context";
 import { Query, Marker, Product, TableRow } from "./schema-types";
-import { GraphQLResolveInfo } from "graphql";
 
 export type RootValue = {};
 

--- a/src/client-graphql/schema-types.ts
+++ b/src/client-graphql/schema-types.ts
@@ -14,6 +14,7 @@ export interface Product {
   readonly key: string;
   readonly name: string;
   readonly retired: boolean;
+  readonly modules: Modules;
   readonly _fileName: string;
 }
 

--- a/src/client-graphql/schema-types.ts
+++ b/src/client-graphql/schema-types.ts
@@ -7,8 +7,6 @@ export interface Marker {
   readonly releaseName?: string;
   // If this marker is a latest marker then it will point to a transactionId
   readonly tx?: string;
-  readonly products?: ReadonlyArray<Product>;
-  readonly _fileName: string;
 }
 
 export interface Product {
@@ -16,7 +14,6 @@ export interface Product {
   readonly key: string;
   readonly name: string;
   readonly retired: boolean;
-  // readonly tx: string;
   readonly _fileName: string;
 }
 

--- a/src/client-graphql/schema-types.ts
+++ b/src/client-graphql/schema-types.ts
@@ -15,7 +15,6 @@ export interface Product {
   readonly name: string;
   readonly retired: boolean;
   readonly modules: Modules;
-  readonly _fileName: string;
 }
 
 export interface Modules {

--- a/src/client-graphql/schema-types.ts
+++ b/src/client-graphql/schema-types.ts
@@ -1,5 +1,16 @@
 import { ProductTableFileCell } from "../file-types";
 
+export interface Query {
+  readonly trees: ReadonlyArray<Tree>;
+  readonly marker: Marker;
+  readonly products: ReadonlyArray<Product>;
+  readonly product: Product | null;
+}
+
+export interface Tree {
+  readonly name: string;
+}
+
 export interface Marker {
   readonly markerName: string;
   // If this marker is a release marker then it will point to a releaseId

--- a/src/client-graphql/schema.ts
+++ b/src/client-graphql/schema.ts
@@ -71,15 +71,24 @@ export async function createSchema(
     fields: {
       trees: {
         type: new GraphQLList(treeType),
+        description: "Trees describes relations between products.",
         resolve: queryResolvers.trees,
       },
       marker: {
         type: new GraphQLNonNull(markerType),
+        description: "Information about the marker for this enpoint.",
         resolve: queryResolvers.marker,
       },
       products: {
-        type: new GraphQLNonNull(GraphQLList(productType)),
+        type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(productType))),
+        description: "Gets all products",
         resolve: queryResolvers.products,
+      },
+      product: {
+        type: productType,
+        args: { id: { type: new GraphQLNonNull(GraphQLID), description: "The Id of the product to get" } },
+        description: "Get a specific product.",
+        resolve: queryResolvers.product,
       },
     },
   });
@@ -101,8 +110,8 @@ async function buildProductType(
       name: { type: new GraphQLNonNull(GraphQLString) },
       retired: { type: new GraphQLNonNull(GraphQLBoolean) },
       modules: modulesType
-        ? { type: modulesType, resolve: productResolvers.modules }
-        : { type: GraphQLString, resolve: () => "No tables found." },
+        ? { type: new GraphQLNonNull(modulesType), resolve: productResolvers.modules }
+        : { type: new GraphQLNonNull(GraphQLString), resolve: () => "No tables found." },
     },
   });
   return productType;

--- a/src/client-graphql/schema.ts
+++ b/src/client-graphql/schema.ts
@@ -27,6 +27,7 @@ export async function createSchema(
   readJsonFile: ReadJsonFile,
   releaseOrTransactionFileName: string
 ): Promise<GraphQLSchema> {
+  console.log("createSchemacreateSchemacreateSchemacreateSchemacreateSchema");
   const usedTypeNames = new Set<string>();
 
   // Read the file that the marker points to, it is either a Release or Transaction file
@@ -105,10 +106,10 @@ async function buildProductType(
   const productType = new GraphQLObjectType({
     name: getUniqueTypeName("Product", usedTypeNames),
     fields: {
-      id: { type: new GraphQLNonNull(GraphQLID) },
-      key: { type: new GraphQLNonNull(GraphQLString) },
-      name: { type: new GraphQLNonNull(GraphQLString) },
-      retired: { type: new GraphQLNonNull(GraphQLBoolean) },
+      id: { type: new GraphQLNonNull(GraphQLID), resolve: productResolvers.id },
+      key: { type: new GraphQLNonNull(GraphQLString), resolve: productResolvers.key },
+      name: { type: new GraphQLNonNull(GraphQLString), resolve: productResolvers.name },
+      retired: { type: new GraphQLNonNull(GraphQLBoolean), resolve: productResolvers.retired },
       modules: modulesType
         ? { type: new GraphQLNonNull(modulesType), resolve: productResolvers.modules }
         : { type: new GraphQLNonNull(GraphQLString), resolve: () => "No tables found." },

--- a/src/client-graphql/schema.ts
+++ b/src/client-graphql/schema.ts
@@ -27,7 +27,6 @@ export async function createSchema(
   readJsonFile: ReadJsonFile,
   releaseOrTransaction: ReleaseFile | TransactionFile
 ): Promise<GraphQLSchema> {
-  console.log("createSchemacreateSchemacreateSchemacreateSchemacreateSchema");
   const usedTypeNames = new Set<string>();
 
   // Read the file that the marker points to, it is either a Release or Transaction file

--- a/src/client-graphql/schema.ts
+++ b/src/client-graphql/schema.ts
@@ -200,10 +200,6 @@ function columnTypeToGraphQLType(c: ProductTableFileColumn): GraphQLScalarType {
   }
 }
 
-// interface TablesPerModule {
-//   readonly [module: string]: ColumnsPerTable;
-// }
-
 interface TablesPerModule {
   readonly [module: string]: TableByName;
 }
@@ -216,10 +212,6 @@ interface Table {
 interface TableByName {
   readonly [tableName: string]: Table;
 }
-
-// interface ColumnsPerTable {
-//   readonly [tableName: string]: ReadonlyArray<ProductTableFileColumn>;
-// }
 
 // All tables that have the same structure can be merged...
 async function getUniqueTableDefinitionsPerModule(

--- a/src/client-graphql/schema.ts
+++ b/src/client-graphql/schema.ts
@@ -125,7 +125,7 @@ async function buildModulesType(
   for (const [n, v] of Object.entries(tablesPerModule)) {
     const moduleFieldName = toSafeName(n);
     fields[moduleFieldName] = {
-      type: await buildModuleType(moduleFieldName, v, usedTypeNames),
+      type: new GraphQLNonNull(await buildModuleType(moduleFieldName, v, usedTypeNames)),
       resolve: modulesFieldResolver,
     };
   }
@@ -145,7 +145,9 @@ async function buildModuleType(
   for (const [n, v] of Object.entries(tableDefs)) {
     const tableFieldName = toSafeName(n);
     fields[tableFieldName] = {
-      type: new GraphQLList(await buildTableRowType(tableFieldName, v.columns, usedTypeNames)),
+      type: new GraphQLNonNull(
+        GraphQLList(new GraphQLNonNull(await buildTableRowType(tableFieldName, v.columns, usedTypeNames)))
+      ),
       description: v.description,
       resolve: moduleFieldResolver,
     };

--- a/src/client-graphql/schema.ts
+++ b/src/client-graphql/schema.ts
@@ -25,13 +25,12 @@ import { ReadJsonFile } from "./context";
 
 export async function createSchema(
   readJsonFile: ReadJsonFile,
-  releaseOrTransactionFileName: string
+  releaseOrTransaction: ReleaseFile | TransactionFile
 ): Promise<GraphQLSchema> {
   console.log("createSchemacreateSchemacreateSchemacreateSchemacreateSchema");
   const usedTypeNames = new Set<string>();
 
   // Read the file that the marker points to, it is either a Release or Transaction file
-  const releaseOrTransaction = await readJsonFile<ReleaseFile | TransactionFile>(releaseOrTransactionFileName);
   const productFileNames = Object.values(releaseOrTransaction.data.products).map(
     (ref) => releaseOrTransaction.refs[ref]
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,6 +672,11 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+dataloader@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+  integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
Reworking some things in the schema, for example moving products to top level and add single product field with ID as argument.

Rework schema generation and resolvers so performance is much better.

Fixes #3.

