### PR TITLE
Add texts plugin with language and name args

### DIFF
--- a/src/client-graphql/modules/texts.ts
+++ b/src/client-graphql/modules/texts.ts
@@ -1,0 +1,51 @@
+import { GraphQLObjectType, GraphQLNonNull, GraphQLFieldConfigMap, GraphQLList, GraphQLString } from "graphql";
+import { getUniqueTypeName } from "../shared-functions";
+import { ModuleFieldResolverParent, TableByName } from "../module-plugin";
+import { buildTableRowTypeFields, parentRowResolver } from "./shared-functions";
+import { Context } from "../context";
+
+/**
+ * This file has specific schema and resolvers for the texts module
+ */
+
+const myModuleName = "texts";
+
+export async function createModuleType(
+  moduleName: string,
+  usedTypeNames: Set<string>,
+  tableByName: TableByName
+): Promise<GraphQLObjectType> {
+  const fields: GraphQLFieldConfigMap<unknown, unknown, unknown> = {};
+  const textTable = tableByName["text"];
+
+  const textRowType = new GraphQLObjectType({
+    name: getUniqueTypeName("Texts_Text", usedTypeNames),
+    fields: {
+      ...buildTableRowTypeFields(textTable.columns),
+    },
+  });
+
+  fields["text"] = {
+    type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(textRowType))),
+    args: {
+      language: { type: GraphQLString },
+      name: { type: GraphQLString },
+    },
+    description: textTable.description,
+    resolve: async (
+      parent: ModuleFieldResolverParent,
+      args: { readonly language?: string; readonly name?: string },
+      ctx: Context
+    ) => {
+      let rows = await parentRowResolver(myModuleName, "text")(parent, args, ctx);
+      if (args.name !== undefined) {
+        rows = rows.filter((r) => r["name"] === args.name);
+      }
+      if (args.language !== undefined) {
+        rows = rows.filter((r) => r["language"] === args.language);
+      }
+      return rows;
+    },
+  };
+  return new GraphQLObjectType({ name: getUniqueTypeName(`Module_${moduleName}`, usedTypeNames), fields });
+}

--- a/src/client-graphql/schema.ts
+++ b/src/client-graphql/schema.ts
@@ -19,6 +19,7 @@ import * as DefaultModule from "./modules/default";
 import * as PropertiesModule from "./modules/properties";
 import * as SoundModule from "./modules/sound";
 import * as ModelsModule from "./modules/models";
+import * as TextsModule from "./modules/texts";
 
 const defaultModulePlugin: ModulePlugin = DefaultModule;
 
@@ -26,6 +27,7 @@ const modulePlugins: { readonly [name: string]: ModulePlugin } = {
   properties: PropertiesModule,
   sound: SoundModule,
   models: ModelsModule,
+  texts: TextsModule,
 };
 
 export const defaultResolveModuleType = (parent: string, _args: {}, _ctx: {}, info: GraphQLResolveInfo) => {


### PR DESCRIPTION
This will make it possible to do a query like this:

```graphql
{
  product(id: "b51d1bd0-20f0-11e8-932a-53b2ed4666ec") {
    id
    key
    modules {
      texts {
        text(language: "Svenska", name:"short_description") {
          sort_no
          property_filter
          name
          language
          text
          comment
        }
      }
    }
  }
}
```

Both `language` and `name` args are optional so this change is backwards compatible.
