### PR TITLE
Fix blank column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/promaster-sdk/api-server/compare/v2.1.0...master)
 
+### Added
+
+- Fix blank column names, see PR #12.
+
 ## [v2.1.0](https://github.com/promaster-sdk/api-server/compare/v1.4.0...v2.1.0) - 2020-11-12
 
 ### Added

--- a/src/client-graphql/modules/default.ts
+++ b/src/client-graphql/modules/default.ts
@@ -15,18 +15,20 @@ export async function createModuleType(
 ): Promise<GraphQLObjectType> {
   const fields: GraphQLFieldConfigMap<unknown, unknown, unknown> = {};
   for (const [n, v] of Object.entries(tableByName)) {
-    const tableFieldName = toSafeName(n);
-    const tableRowType = new GraphQLObjectType({
-      name: getUniqueTypeName(tableFieldName, usedTypeNames),
-      fields: buildTableRowTypeFields(v.columns),
-    });
-    fields[tableFieldName] = {
-      type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(tableRowType))),
-      description: v.description,
-      resolve: (parent: ModuleFieldResolverParent, _args: {}, ctx: Context, info: GraphQLResolveInfo) => {
-        return resolveTableRows(parent.module, info.fieldName, parent.productFileName, ctx.loaders);
-      },
-    };
+    if (n !== "") {
+      const tableFieldName = toSafeName(n);
+      const tableRowType = new GraphQLObjectType({
+        name: getUniqueTypeName(tableFieldName, usedTypeNames),
+        fields: buildTableRowTypeFields(v.columns),
+      });
+      fields[tableFieldName] = {
+        type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(tableRowType))),
+        description: v.description,
+        resolve: (parent: ModuleFieldResolverParent, _args: {}, ctx: Context, info: GraphQLResolveInfo) => {
+          return resolveTableRows(parent.module, info.fieldName, parent.productFileName, ctx.loaders);
+        },
+      };
+    }
   }
   return new GraphQLObjectType({ name: getUniqueTypeName(`Module_${moduleFieldName}`, usedTypeNames), fields });
 }

--- a/src/client-graphql/modules/shared-functions.ts
+++ b/src/client-graphql/modules/shared-functions.ts
@@ -58,7 +58,9 @@ export function buildTableRowTypeFields(
   columns: ReadonlyArray<ProductTableFileColumn>
 ): GraphQLFieldConfigMap<unknown, unknown> {
   return Object.fromEntries(
-    columns.map((c) => [toSafeName(c.name), { type: columnTypeToGraphQLType(c), description: c.description }])
+    columns
+      .filter((c) => c.name !== "")
+      .map((c) => [toSafeName(c.name), { type: columnTypeToGraphQLType(c), description: c.description }])
   );
 }
 

--- a/src/client-graphql/shared-functions.ts
+++ b/src/client-graphql/shared-functions.ts
@@ -1,9 +1,10 @@
 export function getUniqueTypeName(requestedName: string, usedTypeNames: Set<string>): string {
-  if (usedTypeNames.has(requestedName)) {
+  const safeRequestedName = toSafeName(requestedName);
+  if (usedTypeNames.has(safeRequestedName)) {
     return getUniqueTypeName(requestedName + "A", usedTypeNames);
   }
-  usedTypeNames.add(requestedName);
-  return requestedName;
+  usedTypeNames.add(safeRequestedName);
+  return safeRequestedName;
 }
 
 export function toSafeName(name: string): string {


### PR DESCRIPTION
When a column name is blank in promaster the schema would be built with a blank field name which is not supported by GraphQL.