### PR TITLE
Correct rest filterRootTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/promaster-sdk/api-server/compare/v2.3.0...master)
 
+- Adjusted rest/v3 to allow table magicloud.group.definition. This is how it was done in the old Rest API
+
 ## [v2.3.0](https://github.com/promaster-sdk/api-server/compare/v2.2.4...v2.3.0) - 2021-05-10
 
 ### Fixed

--- a/src/client-rest/middleware.ts
+++ b/src/client-rest/middleware.ts
@@ -567,7 +567,7 @@ async function getApiProductsForFileNames(
 
 function filterRootTables(tableNames: ReadonlyArray<string>): ReadonlyArray<string> {
   // This is to be compatible with v2 which only returns root tables, it was done the same way in Dart
-  return tableNames.filter((t) => t.indexOf(".") === -1 && t !== "magicloud");
+  return tableNames.filter((t) => (t.indexOf(".") === -1 && t !== "magicloud") || t === "magicloud.group.definition");
 }
 
 interface LegacyChildTablesPerParent {


### PR DESCRIPTION
The Rest api is not compatibale with promasters old api. The old implementation in Dart was:
product.tables.values.where((t) => (!t.name.contains('.') && t.name != "magicloud") **|| t.name == "magicloud.group.definition"**)

This pull requests adjusts it to match the old rest API