### PR TITLE
Fix duplicated translations for backwards compatible property value texts

### DIFF
--- a/src/client-rest/middleware-test-files/property-value-translation-in-text-table/files-dir/table_4041926f-f143-4ded-b487-0cfd4a2eac28@788145.json
+++ b/src/client-rest/middleware-test-files/property-value-translation-in-text-table/files-dir/table_4041926f-f143-4ded-b487-0cfd4a2eac28@788145.json
@@ -16,7 +16,8 @@
     "rows": [
       ["9d55ce5b-a346-473d-b138-552eb51fe52b", 0, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "400", null, null, null],
       ["04bb87bb-ebbe-4936-b2e2-aaa52c9e9d55", 1, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "600", null, null, null],
-      ["54582389-185b-42d1-a94f-407efa54df23", 2, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "800", null, null, null]
+      ["54582389-185b-42d1-a94f-407efa54df23", 2, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "800", null, null, null],
+      ["54582389-185b-42d1-a94f-407efa54df23", 3, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "4000", null, null, null]
     ]
   },
   "refs": {}

--- a/src/client-rest/middleware-test-files/property-value-translation-in-text-table/files-dir/table_c1981b21-df82-46e9-96d8-45950047914c@912752.json
+++ b/src/client-rest/middleware-test-files/property-value-translation-in-text-table/files-dir/table_c1981b21-df82-46e9-96d8-45950047914c@912752.json
@@ -19,7 +19,9 @@
       ["fake-3", 1009, null, "pv_width_600", "en-US", "600", null],
       ["fake-4", 1010, null, "pv_width_600", "sv-SE", "600", null],
       ["fake-5", 1009, null, "pv_width_800", "en-US", "800", null],
-      ["fake-6", 1010, null, "pv_width_800", "sv-SE", "800", null]
+      ["fake-6", 1010, null, "pv_width_800", "sv-SE", "800", null],
+      ["fake-7", 1009, null, "pv_width_4000", "en-US", "4000", null],
+      ["fake-8", 1010, null, "pv_width_4000", "sv-SE", "4000", null]
     ]
   },
   "refs": {}

--- a/src/client-rest/middleware-test-files/property-value-translation-in-text-table/result.json
+++ b/src/client-rest/middleware-test-files/property-value-translation-in-text-table/result.json
@@ -67,6 +67,25 @@
                 "translation": "800"
               }
             ]
+          },
+          {
+            "sort_no": 3,
+            "value": "4000",
+            "property_filter": null,
+            "image": null,
+            "description": null,
+            "translation": [
+              {
+                "sort_no": 0,
+                "language": "en-US",
+                "translation": "4000"
+              },
+              {
+                "sort_no": 1,
+                "language": "sv-SE",
+                "translation": "4000"
+              }
+            ]
           }
         ]
       }

--- a/src/client-rest/middleware.ts
+++ b/src/client-rest/middleware.ts
@@ -572,10 +572,10 @@ async function mapFileRowsToApiRows(
               (col) => col.name === "text"
             );
 
-            const translationPrefix = "pv_" + parent?.value + "_" + apiRow["value"];
+            const translationKey = "pv_" + parent?.value + "_" + apiRow["value"];
 
             const propertyTranslations = textTablePropertyValueTranslation.data.rows
-              .filter((row) => (row[nameColumnIndex]?.toString() ?? null)?.startsWith(translationPrefix))
+              .filter((row) => row[nameColumnIndex]?.toString() === translationKey)
               .map((row): {
                 name: string | null;
                 laguage: string | null;


### PR DESCRIPTION
Fixes #53 

This PR modifies a test to cover the issue.

It solves the issue by requiring the translation key to be an exact match instead of just starting with it.