### PR TITLE
Fix duplicate property translations when property name starts with same prefix

### DIFF
--- a/src/client-rest/middleware-test-files/property-translation-in-text-table/files-dir/table_66c88372-ae07-4916-9dcf-4e6908820630@788145.json
+++ b/src/client-rest/middleware-test-files/property-translation-in-text-table/files-dir/table_66c88372-ae07-4916-9dcf-4e6908820630@788145.json
@@ -14,7 +14,10 @@
       { "type": "PropertyFilter", "name": "validation_filter" },
       { "type": "Quantity", "name": "quantity" }
     ],
-    "rows": [["9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", 0, "width", null, null, null, null, "Discrete"]]
+    "rows": [
+      ["9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", 0, "width", null, null, null, null, "Discrete"],
+      ["9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", 0, "width2", null, null, null, null, "Discrete"]
+    ]
   },
   "refs": {}
 }

--- a/src/client-rest/middleware-test-files/property-translation-in-text-table/files-dir/table_c1981b21-df82-46e9-96d8-45950047914c@912752.json
+++ b/src/client-rest/middleware-test-files/property-translation-in-text-table/files-dir/table_c1981b21-df82-46e9-96d8-45950047914c@912752.json
@@ -16,8 +16,8 @@
     "rows": [
       ["d2720613-1519-49c4-b4e7-690f6795d839", 1009, null, "p_standard_width", "en-US", "Width", null],
       ["0002c2e6-e53e-4b05-a917-9f9fc8d01c90", 1010, null, "p_standard_width", "sv-SE", "Bredd", null],
-      ["d2720613-1519-49c4-b4e7-690f6795d839", 1109, null, "p_standard_width2", "en-US", "Width", null],
-      ["0002c2e6-e53e-4b05-a917-9f9fc8d01c90", 1110, null, "p_standard_width2", "sv-SE", "Bredd", null]
+      ["d2720613-1519-49c4-b4e7-690f6795d839", 1109, null, "p_standard_width2", "en-US", "Width2", null],
+      ["0002c2e6-e53e-4b05-a917-9f9fc8d01c90", 1110, null, "p_standard_width2", "sv-SE", "Bredd2", null]
     ]
   },
   "refs": {}

--- a/src/client-rest/middleware-test-files/property-translation-in-text-table/files-dir/table_c1981b21-df82-46e9-96d8-45950047914c@912752.json
+++ b/src/client-rest/middleware-test-files/property-translation-in-text-table/files-dir/table_c1981b21-df82-46e9-96d8-45950047914c@912752.json
@@ -15,7 +15,9 @@
     ],
     "rows": [
       ["d2720613-1519-49c4-b4e7-690f6795d839", 1009, null, "p_standard_width", "en-US", "Width", null],
-      ["0002c2e6-e53e-4b05-a917-9f9fc8d01c90", 1010, null, "p_standard_width", "sv-SE", "Bredd", null]
+      ["0002c2e6-e53e-4b05-a917-9f9fc8d01c90", 1010, null, "p_standard_width", "sv-SE", "Bredd", null],
+      ["d2720613-1519-49c4-b4e7-690f6795d839", 1109, null, "p_standard_width2", "en-US", "Width", null],
+      ["0002c2e6-e53e-4b05-a917-9f9fc8d01c90", 1110, null, "p_standard_width2", "sv-SE", "Bredd", null]
     ]
   },
   "refs": {}

--- a/src/client-rest/middleware-test-files/property-translation-in-text-table/result.json
+++ b/src/client-rest/middleware-test-files/property-translation-in-text-table/result.json
@@ -23,6 +23,29 @@
             "translation": "Bredd"
           }
         ]
+      },
+      {
+        "sort_no": 0,
+        "name": "width2",
+        "group": null,
+        "image": null,
+        "visibility_filter": null,
+        "validation_filter": null,
+        "quantity": "Discrete",
+        "translation": [
+          {
+            "sort_no": 0,
+            "language": "en-US",
+            "type": null,
+            "translation": "Width2"
+          },
+          {
+            "sort_no": 1,
+            "language": "sv-SE",
+            "type": null,
+            "translation": "Bredd2"
+          }
+        ]
       }
     ]
   }

--- a/src/client-rest/middleware.ts
+++ b/src/client-rest/middleware.ts
@@ -535,10 +535,10 @@ async function mapFileRowsToApiRows(
             );
             const textColumnIndex = textTablePropertyTranslation.data.columns.findIndex((col) => col.name === "text");
 
-            const translationPrefix = "p_standard_" + apiRow["name"];
+            const translationKey = "p_standard_" + apiRow["name"];
 
             const propertyTranslations = textTablePropertyTranslation.data.rows
-              .filter((row) => (row[nameColumnIndex]?.toString() ?? null)?.startsWith(translationPrefix))
+              .filter((row) => row[nameColumnIndex]?.toString()  === translationKey)
               .map((row): {
                 name: string | null;
                 laguage: string | null;


### PR DESCRIPTION
This will fix a bug in the combability layer that will give multiple translations if more than one property starts with the same prefix.