### PR TITLE
Better error-handling in graphql-queries for standard modules

### DIFF
--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/product_342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d@788145.json
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/product_342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d@788145.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": "342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d",
+    "key": "DEMODAMPER",
+    "name": "",
+    "description": "",
+    "retired": false,
+    "tables": {
+      "custom_tables@table1": 16
+    }
+  },
+  "refs": {
+    "16": "table_66c88372-ae07-4916-9dcf-4e6908820630@778616.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/product_442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e@788146.json
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/product_442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e@788146.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": "442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e",
+    "key": "DEMODAMPER2",
+    "name": "",
+    "description": "",
+    "retired": false,
+    "tables": {
+      "custom_tables@table1": 16
+    }
+  },
+  "refs": {
+    "16": "table_76c88372-ae07-4916-9dcf-4e6908820631@778617.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/release_ddd45f4a-2b29-410c-a054-4266361385a4.json
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/release_ddd45f4a-2b29-410c-a054-4266361385a4.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "ddd45f4a-2b29-410c-a054-4266361385a4",
+    "name": "TEST",
+    "products": {
+      "342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d": 1,
+      "442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e": 2
+    }
+  },
+  "refs": {
+    "1": "product_342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d@788145.json",
+    "2": "product_442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e@788146.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/root.json
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/root.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "markers": { "PRODUCTION": 0 },
+    "latest": { "tx": 912752, "transaction": 2, "date": 1695716048809 },
+    "trees": { "73839479-3059-475a-8282-326c3b27e5b5": 3 }
+  },
+  "refs": {
+    "0": "release_ddd45f4a-2b29-410c-a054-4266361385a4.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/table_66c88372-ae07-4916-9dcf-4e6908820630@778616.json
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/table_66c88372-ae07-4916-9dcf-4e6908820630@778616.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": "66c88372-ae07-4916-9dcf-4e6908820630",
+    "module": "custom_tables",
+    "name": "table1",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "Text", "name": "name" },
+      { "type": "Text", "name": "comment" }
+    ],
+    "rows": [["9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", 0, "width", "a comment"]]
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/table_76c88372-ae07-4916-9dcf-4e6908820631@778617.json
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/files-dir/table_76c88372-ae07-4916-9dcf-4e6908820631@778617.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": "76c88372-ae07-4916-9dcf-4e6908820631",
+    "module": "custom_tables",
+    "name": "table1",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "Text", "name": "name" }
+    ],
+    "rows": [["aa7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50d", 0, "width"]]
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/query.graphql
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/query.graphql
@@ -1,0 +1,15 @@
+{
+  products {
+    id
+    name
+    modules {
+      custom_tables {
+        table1 {
+          builtin_id
+          name
+          comment
+        }
+      }
+    }
+  }
+}

--- a/src/client-graphql/middleware-test-files/custom-table-columns-diff/result.json
+++ b/src/client-graphql/middleware-test-files/custom-table-columns-diff/result.json
@@ -1,0 +1,5 @@
+[
+  {
+    "errors": [{ "message": "Cannot query field \"table1\" on type \"Module_custom_tables\"." }]
+  }
+]

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/product_342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d@788145.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/product_342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d@788145.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "id": "342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d",
+    "key": "DEMODAMPER",
+    "name": "",
+    "description": "",
+    "retired": false,
+    "tables": {
+      "properties@property": 16,
+      "properties@property.def_value": 17,
+      "properties@property.value": 18
+    }
+  },
+  "refs": {
+    "16": "table_66c88372-ae07-4916-9dcf-4e6908820630@778616.json",
+    "17": "table_da231ae4-3a26-4248-800e-647c406de494@778616.json",
+    "18": "table_4041926f-f143-4ded-b487-0cfd4a2eac28@778616.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/product_442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e@788146.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/product_442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e@788146.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "id": "442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e",
+    "key": "DEMODAMPER2",
+    "name": "",
+    "description": "",
+    "retired": false,
+    "tables": {
+      "properties@property": 16,
+      "properties@property.def_value": 17,
+      "properties@property.value": 18
+    }
+  },
+  "refs": {
+    "16": "table_76c88372-ae07-4916-9dcf-4e6908820631@778617.json",
+    "17": "table_ea231ae4-3a26-4248-800e-647c406de495@778617.json",
+    "18": "table_5041926f-f143-4ded-b487-0cfd4a2eac29@778617.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/release_ddd45f4a-2b29-410c-a054-4266361385a4.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/release_ddd45f4a-2b29-410c-a054-4266361385a4.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": "ddd45f4a-2b29-410c-a054-4266361385a4",
+    "name": "TEST",
+    "products": {
+      "342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d": 1,
+      "442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e": 2
+    }
+  },
+  "refs": {
+    "1": "product_342da2d8-7e2c-4ef4-ba2c-1210adfa1a0d@788145.json",
+    "2": "product_442da2d8-7e2c-4ef4-ba2c-1210adfa1a0e@788146.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/root.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/root.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "markers": { "PRODUCTION": 0 },
+    "latest": { "tx": 912752, "transaction": 2, "date": 1695716048809 },
+    "trees": { "73839479-3059-475a-8282-326c3b27e5b5": 3 }
+  },
+  "refs": {
+    "0": "release_ddd45f4a-2b29-410c-a054-4266361385a4.json"
+  }
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_4041926f-f143-4ded-b487-0cfd4a2eac28@778616.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_4041926f-f143-4ded-b487-0cfd4a2eac28@778616.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "id": "4041926f-f143-4ded-b487-0cfd4a2eac28",
+    "module": "properties",
+    "name": "property.value",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "ForeignKey", "name": "builtin@parent_id", "params": "property" },
+      { "type": "Text", "name": "value", "key": true },
+      { "type": "PropertyFilter", "name": "property_filter" },
+      { "type": "Blob", "name": "image", "params": "image_filename" },
+      { "type": "Text", "name": "description" }
+    ],
+    "rows": [
+      ["9d55ce5b-a346-473d-b138-552eb51fe52b", 0, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "400", null, null, null],
+      ["04bb87bb-ebbe-4936-b2e2-aaa52c9e9d55", 1, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "600", null, null, null],
+      ["54582389-185b-42d1-a94f-407efa54df23", 2, "9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", "800", null, null, null]
+    ]
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_5041926f-f143-4ded-b487-0cfd4a2eac29@778617.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_5041926f-f143-4ded-b487-0cfd4a2eac29@778617.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "id": "5041926f-f143-4ded-b487-0cfd4a2eac29",
+    "module": "properties",
+    "name": "property.value",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "ForeignKey", "name": "builtin@parent_id", "params": "property" },
+      { "type": "Text", "name": "value", "key": true },
+      { "type": "PropertyFilter", "name": "property_filter" },
+      { "type": "Blob", "name": "image", "params": "image_filename" },
+      { "type": "Text", "name": "description" }
+    ],
+    "rows": [
+      ["ad55ce5b-a346-473d-b138-552eb51fe52c", 0, "aa7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50d", "400", null, null, null],
+      ["14bb87bb-ebbe-4936-b2e2-aaa52c9e9d56", 1, "aa7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50d", "600", null, null, null],
+      ["64582389-185b-42d1-a94f-407efa54df24", 2, "aa7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50d", "800", null, null, null]
+    ]
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_66c88372-ae07-4916-9dcf-4e6908820630@778616.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_66c88372-ae07-4916-9dcf-4e6908820630@778616.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "id": "66c88372-ae07-4916-9dcf-4e6908820630",
+    "module": "properties",
+    "name": "property",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "Text", "name": "name", "params": "property.name", "key": true },
+      { "type": "Text", "name": "group", "params": "property.group" },
+      { "type": "Blob", "name": "image", "params": "image_filename" },
+      { "type": "PropertyFilter", "name": "visibility_filter" },
+      { "type": "PropertyFilter", "name": "validation_filter" },
+      { "type": "Quantity", "name": "quantity" },
+      { "type": "Text", "name": "comment" }
+    ],
+    "rows": [["9a7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50c", 0, "width", null, null, null, null, "Discrete", "a comment"]]
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_76c88372-ae07-4916-9dcf-4e6908820631@778617.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_76c88372-ae07-4916-9dcf-4e6908820631@778617.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "id": "76c88372-ae07-4916-9dcf-4e6908820631",
+    "module": "properties",
+    "name": "property",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "Text", "name": "name", "params": "property.name", "key": true },
+      { "type": "Text", "name": "group", "params": "property.group" },
+      { "type": "Blob", "name": "image", "params": "image_filename" },
+      { "type": "PropertyFilter", "name": "visibility_filter" },
+      { "type": "PropertyFilter", "name": "validation_filter" },
+      { "type": "Quantity", "name": "quantity" }
+    ],
+    "rows": [["aa7ddbfb-83ab-4e0f-b7b3-c99ad8b0f50d", 0, "width", null, null, null, null, "Discrete"]]
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_da231ae4-3a26-4248-800e-647c406de494@778616.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_da231ae4-3a26-4248-800e-647c406de494@778616.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": "da231ae4-3a26-4248-800e-647c406de494",
+    "module": "properties",
+    "name": "property.def_value",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "Text", "name": "value", "key": true },
+      { "type": "PropertyFilter", "name": "property_filter" }
+    ],
+    "rows": []
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_ea231ae4-3a26-4248-800e-647c406de495@778617.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/files-dir/table_ea231ae4-3a26-4248-800e-647c406de495@778617.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": "ea231ae4-3a26-4248-800e-647c406de495",
+    "module": "properties",
+    "name": "property.def_value",
+    "description": "",
+    "columns": [
+      { "type": "PrimaryKey", "name": "builtin@id" },
+      { "type": "Number", "name": "sort_no" },
+      { "type": "Text", "name": "value", "key": true },
+      { "type": "PropertyFilter", "name": "property_filter" }
+    ],
+    "rows": []
+  },
+  "refs": {}
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/query.graphql
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/query.graphql
@@ -1,0 +1,15 @@
+{
+  products {
+    id
+    name
+    modules {
+      properties {
+        property {
+          builtin_id
+          name
+          comment
+        }
+      }
+    }
+  }
+}

--- a/src/client-graphql/middleware-test-files/property-columns-diff/result.json
+++ b/src/client-graphql/middleware-test-files/property-columns-diff/result.json
@@ -1,0 +1,5 @@
+[
+  {
+    "errors": [{ "message": "Cannot query field \"property\" on type \"Module_properties\"." }]
+  }
+]

--- a/src/client-graphql/middleware.test.ts
+++ b/src/client-graphql/middleware.test.ts
@@ -42,7 +42,17 @@ describe("createSchema", async () => {
 
       const result = await readJsonFile(currentTestFilesFolder)("result.json");
 
-      expect(responses).toEqual(result);
+      // GraphQL errors doesn't map to json, so we have to fix it manually
+      const errorMessages = responses
+        .filter((r) => r.errors)
+        .flatMap((r) => r.errors!.map((err) => ({ message: err.message })));
+      const errors = errorMessages.length > 0 ? [{ errors: errorMessages }] : undefined;
+
+      if (errors) {
+        expect(errors).toEqual(result);
+      } else {
+        expect(responses).toEqual(result);
+      }
     });
   }
 });

--- a/src/client-graphql/modules/models.ts
+++ b/src/client-graphql/modules/models.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLNonNull, GraphQLFieldConfigMap, GraphQLList } from "graphql";
+import { GraphQLObjectType, GraphQLNonNull, GraphQLFieldConfigMap, GraphQLList, GraphQLString } from "graphql";
 import { getUniqueTypeName } from "../shared-functions";
 import { TableByName } from "../module-plugin";
 import { buildTableRowTypeFields, childRowResolver, parentRowResolver } from "./shared-functions";
@@ -16,10 +16,19 @@ export async function createModuleType(
 ): Promise<GraphQLObjectType> {
   const fields: GraphQLFieldConfigMap<unknown, unknown> = {};
   const modelTable = tableByName["model"];
+  const modelParamsTable = tableByName["model.params"];
+
+  if (modelTable === undefined || modelParamsTable === undefined) {
+    fields["models_type_error"] = {
+      type: GraphQLString,
+      description: "models type error: cannot find model/model.params",
+    };
+    return new GraphQLObjectType({ name: getUniqueTypeName(`Module_${moduleName}`, usedTypeNames), fields });
+  }
 
   const modelParamsRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Model_Params", usedTypeNames),
-    fields: buildTableRowTypeFields(tableByName["model.params"].columns),
+    fields: buildTableRowTypeFields(modelParamsTable.columns),
   });
 
   const modelRowType = new GraphQLObjectType({

--- a/src/client-graphql/modules/properties.ts
+++ b/src/client-graphql/modules/properties.ts
@@ -24,6 +24,16 @@ export async function createModuleType(
 ): Promise<GraphQLObjectType> {
   const fields: GraphQLFieldConfigMap<unknown, unknown> = {};
   const propertyTable = tableByName["property"];
+  const propertyDefValueTable = tableByName["property.def_value"];
+  const propertyValueTable = tableByName["property.value"];
+
+  if (propertyTable === undefined || propertyDefValueTable === undefined || propertyValueTable === undefined) {
+    fields["property_type_error"] = {
+      type: GraphQLString,
+      description: "property type error: cannot find property/property.def_value/property.value",
+    };
+    return new GraphQLObjectType({ name: getUniqueTypeName(`Module_${moduleName}`, usedTypeNames), fields });
+  }
 
   const propertyValueTranslationRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Property_ValueTranslation", usedTypeNames),
@@ -56,13 +66,13 @@ export async function createModuleType(
 
   const propertyDefaultValueRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Property_DefaultValue", usedTypeNames),
-    fields: buildTableRowTypeFields(tableByName["property.def_value"].columns),
+    fields: buildTableRowTypeFields(propertyDefValueTable.columns),
   });
 
   const propertyValueRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Property_Value", usedTypeNames),
     fields: {
-      ...buildTableRowTypeFields(tableByName["property.value"].columns),
+      ...buildTableRowTypeFields(propertyValueTable.columns),
       translations: {
         type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(propertyValueTranslationRowType))),
         args: { language: { type: GraphQLString, description: "The language to get translations for" } },

--- a/src/client-graphql/modules/sound.ts
+++ b/src/client-graphql/modules/sound.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLNonNull, GraphQLFieldConfigMap, GraphQLList } from "graphql";
+import { GraphQLObjectType, GraphQLNonNull, GraphQLFieldConfigMap, GraphQLList, GraphQLString } from "graphql";
 import { getUniqueTypeName } from "../shared-functions";
 import { TableByName } from "../module-plugin";
 import { buildTableRowTypeFields, childRowResolver, parentRowResolver } from "./shared-functions";
@@ -16,20 +16,37 @@ export async function createModuleType(
 ): Promise<GraphQLObjectType> {
   const fields: GraphQLFieldConfigMap<unknown, unknown> = {};
   const soundVariantTable = tableByName["sound_variant"];
+  const soundVariantDamperTable = tableByName["sound_variant.damper"];
+  const soundVariantSoundlineTable = tableByName["sound_variant.sound_line"];
+  const soundVariantSoundTable = tableByName["sound_variant.sound"];
+
+  if (
+    soundVariantTable === undefined ||
+    soundVariantDamperTable === undefined ||
+    soundVariantSoundlineTable === undefined ||
+    soundVariantSoundTable === undefined
+  ) {
+    fields["sound_type_error"] = {
+      type: GraphQLString,
+      description:
+        "sound type error: cannot find sound_variant/sound_variant.damper/sound_variant.sound_line/sound_variant.sound",
+    };
+    return new GraphQLObjectType({ name: getUniqueTypeName(`Module_${moduleName}`, usedTypeNames), fields });
+  }
 
   const damperRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Sound_Damper", usedTypeNames),
-    fields: buildTableRowTypeFields(tableByName["sound_variant.damper"].columns),
+    fields: buildTableRowTypeFields(soundVariantDamperTable.columns),
   });
 
   const soundLineRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Sound_SoundLine", usedTypeNames),
-    fields: buildTableRowTypeFields(tableByName["sound_variant.sound_line"].columns),
+    fields: buildTableRowTypeFields(soundVariantSoundlineTable.columns),
   });
 
   const soundRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Sound_Sound", usedTypeNames),
-    fields: buildTableRowTypeFields(tableByName["sound_variant.sound"].columns),
+    fields: buildTableRowTypeFields(soundVariantSoundTable.columns),
   });
 
   const soundVariantRowType = new GraphQLObjectType({

--- a/src/client-graphql/modules/texts.ts
+++ b/src/client-graphql/modules/texts.ts
@@ -18,6 +18,14 @@ export async function createModuleType(
   const fields: GraphQLFieldConfigMap<unknown, unknown> = {};
   const textTable = tableByName["text"];
 
+  if (textTable === undefined) {
+    fields["texts_type_error"] = {
+      type: GraphQLString,
+      description: "texts type error: cannot find text",
+    };
+    return new GraphQLObjectType({ name: getUniqueTypeName(`Module_${moduleName}`, usedTypeNames), fields });
+  }
+
   const textRowType = new GraphQLObjectType({
     name: getUniqueTypeName("Texts_Text", usedTypeNames),
     fields: {


### PR DESCRIPTION
Better error-handling in graphql-queries for standard modules.
This is for the use-case where expected tables are missing under their standard-name, due to column-definitions mismatch between products published from Promaster. A change in a table-definition may have been applied to one product, but not to another.
Previously we got a hard-crash when trying to access the table in code when creating the graphql-schema. Now the schema is created and we get a graphql-error instead when querying the product-data.

Fixes #56 
